### PR TITLE
Strip URL params from filename

### DIFF
--- a/src/ImageUploader.php
+++ b/src/ImageUploader.php
@@ -74,6 +74,7 @@ class ImageUploader
     public function getFilename()
     {
         $filename = basename($this->url);
+        $filename = preg_replace("#\?(.*?)$#si", "", $filename);   // remove URL params from filename
         preg_match('/(.*)?(\.+[^.]*)$/', $filename, $name_parts);
 
         $this->filename = $name_parts[1];


### PR DESCRIPTION
This will strip source URL params and the added '?' in filenames - addresses this issue: https://wordpress.org/support/topic/a-couple-of-issues-related-to-remote-image-file-name/